### PR TITLE
Prepend multiple zeros

### DIFF
--- a/src/pot.erl
+++ b/src/pot.erl
@@ -64,8 +64,7 @@ hotp(Secret, IntervalsNo, Opts) ->
     TokenBase = TokenBase0 band 16#7fffffff,
     Token0 = TokenBase rem trunc(math:pow(10, TokenLength)),
     Token1 = integer_to_binary(Token0),
-    <<48:(TokenLength - byte_size(Token1))/integer-unit:8, Token1/binary>>.
-
+    prepend_zeros(Token1, TokenLength - byte_size(Token1)).
 
 -spec totp(secret()) -> token().
 totp(Secret) ->
@@ -131,3 +130,10 @@ check_candidate(Token, Secret, Current, Last, Opts) when Current =< Last ->
                     Current;
                 _ ->
                     check_candidate(Token, Secret, Current + 1, Last, Opts) end end.
+
+-spec prepend_zeros(token(), pos_integer()) -> token().
+prepend_zeros(Token, N) ->
+    case N of
+        0 -> Token;
+        _ -> prepend_zeros(<<48:8,Token/binary>>, N-1)
+    end.

--- a/test/hotp_generation_tests.erl
+++ b/test/hotp_generation_tests.erl
@@ -19,6 +19,11 @@ hotp_generation_with_padding_test_() ->
             fun stop/1,
             fun hotp_generation_with_padding/1}.
 
+hotp_generation_with_multiple_padding_test_() ->
+    {setup, fun start/0,
+            fun stop/1,
+            fun hotp_generation_with_multiple_padding/1}.
+
 
 start() ->
     ok.
@@ -41,3 +46,7 @@ hotp_generation_for_different_intervals(_) ->
 hotp_generation_with_padding(_) ->
    Secret = <<"MFRGGZDFMZTWQ2LK">>,
    [?_assertEqual(pot:hotp(Secret, 19), <<"088239">>)].
+
+hotp_generation_with_multiple_padding(_) ->
+   Secret = <<"RWLMFU237M4RJIFA">>,
+   [?_assertEqual(pot:hotp(Secret, 48930987), <<"000371">>)].


### PR DESCRIPTION
I was getting intermittent failures validating codes.  The problem was in the leading zero padding code.  It only correctly prepends a single ascii zero. E.g., for a code like "000371" it produces `<<0, 0, 48, 51, 55, 49>>`, instead of `<<48, 48, 48, 51, 55, 49>>`.   

I'm Not very familiar with Erlang code, so not sure if I used an appropriate idiom for fixing.
