### PR TITLE
Added Support for Android Devices without time compensation fix

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 Jonathan Merriweather
 Erik Reedstrom
 Peter McLain
+Pedro Vieira

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2016 Yüce Tekol
+Copyright (c) 2014-2017 Yüce Tekol
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software
 and associated documentation files (the "Software"), to deal in the Software without

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ In order to learn more about one time password generation, see the following Wik
 
 ## News
 
+- **2017/08/03**
+  - Added options to support Android devices (Thanks to Pedro Vieira)
 - **2016/07/30**
   - Released version 0.9.5 with bug fixes (Thanks to Peter McLain)
 - **2015/01/20**
@@ -80,7 +82,7 @@ Include POT in your `mix.exs` as a dependency:
 
 ```elixir
 defp deps do
-    [{:pot, "~>0.9.5"}]
+    [{:pot, "~>0.9.6"}]
 end
 ```
 
@@ -129,7 +131,7 @@ is_valid = :pot.valid_hotp(token, secret, [{:last, last_used}])
 
 ## License
 
-Copyright (c) 2014-2016 Yüce Tekol
+Copyright (c) 2014-2017 Yüce Tekol
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software
 and associated documentation files (the "Software"), to deal in the Software without

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In order to learn more about one time password generation, see the following Wik
 
 ## News
 
-- **2017/08/03**
+- **2017/08/04**
   - Added options to support Android devices (Thanks to Pedro Vieira)
 - **2016/07/30**
   - Released version 0.9.5 with bug fixes (Thanks to Peter McLain)

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ is_valid = :pot.valid_hotp(token, secret, [{:last, last_used}])
 ```elixir
 secret = "MFRGGZDFMZTWQ2LK"
 token = "123456"
-is_valid = :pot.valid_totp(token, secret, [window: 1, addseconds: 30])
+is_valid = :pot.valid_totp(token, secret, [window: 1, addwindow: 1])
 # Do something
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ is_valid = :pot.valid_hotp(token, secret, [{:last, last_used}])
 # Do something
 ```
 
+### Check some time based token on Android devices with 15 seconds ahead
+
+```elixir
+secret = "MFRGGZDFMZTWQ2LK"
+token = "123456"
+is_valid = :pot.valid_totp(token, secret, [window: 1, addseconds: 30])
+# Do something
+```
+
 ## Credits
 
 - Yuce Tekol

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ is_valid = :pot.valid_hotp(token, secret, [{:last, last_used}])
 # Do something
 ```
 
+### Create a time based token with 30 seconds ahead
+
+```elixir
+secret = "MFRGGZDFMZTWQ2LK"
+is_valid = :pot.totp(secret, [addwindow: 1])
+# Do something
+```
+
 ### Check some time based token on Android devices with 15 seconds ahead
 
 ```elixir

--- a/src/pot.app.src
+++ b/src/pot.app.src
@@ -17,7 +17,7 @@
 
 {application, pot,
  [{description, "POT is an Erlang library for generating Google Authenticator compatible one time passwords."},
-  {vsn, "0.9.6"},
+  {vsn, "0.9.6.1"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/pot.app.src
+++ b/src/pot.app.src
@@ -17,7 +17,7 @@
 
 {application, pot,
  [{description, "POT is an Erlang library for generating Google Authenticator compatible one time passwords."},
-  {vsn, "0.9.6"},
+  {vsn, "0.9.7"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/pot.app.src
+++ b/src/pot.app.src
@@ -17,7 +17,7 @@
 
 {application, pot,
  [{description, "POT is an Erlang library for generating Google Authenticator compatible one time passwords."},
-  {vsn, "0.9.6.1"},
+  {vsn, "0.9.6"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/pot.app.src
+++ b/src/pot.app.src
@@ -17,7 +17,7 @@
 
 {application, pot,
  [{description, "POT is an Erlang library for generating Google Authenticator compatible one time passwords."},
-  {vsn, "0.9.7"},
+  {vsn, "0.9.6"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/pot.app.src
+++ b/src/pot.app.src
@@ -1,4 +1,4 @@
-%% Copyright (c) 2014-2016 Yüce Tekol
+%% Copyright (c) 2014-2017 Yüce Tekol
 %
 %% Permission is hereby granted, free of charge, to any person obtaining a copy of this software
 %% and associated documentation files (the "Software"), to deal in the Software without

--- a/src/pot.app.src
+++ b/src/pot.app.src
@@ -17,7 +17,7 @@
 
 {application, pot,
  [{description, "POT is an Erlang library for generating Google Authenticator compatible one time passwords."},
-  {vsn, "0.9.5"},
+  {vsn, "0.9.6"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -115,7 +115,7 @@ valid_totp(Token, Secret, Opts) ->
 
 
 time_interval(Opts) ->
-  AddSeconds = proplists:get_value(addseconds, Opts, 0)
+  AddSeconds = proplists:get_value(addseconds, Opts, 0),
   IntervalLength = proplists:get_value(interval_length, Opts, 30),
   {MegaSecs, Secs, _} = os:timestamp(),
   trunc((MegaSecs * 1000000 + (Secs + AddSeconds)) / IntervalLength).

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2014-2016 Yüce Tekol
+%% Copyright (c) 2014-2017 Yüce Tekol
 %
 %% Permission is hereby granted, free of charge, to any person obtaining a copy of this software
 %% and associated documentation files (the "Software"), to deal in the Software without
@@ -23,7 +23,6 @@
 -export([valid_hotp/2, valid_hotp/3]).
 -export([valid_totp/2, valid_totp/3]).
 -export([time_interval/1]).
--export([check_candidate/5]).
 
 
 -type token() :: binary().
@@ -111,7 +110,10 @@ valid_totp(Token, Secret, Opts) ->
                     true;
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
-                    check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) end;
+                    case check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) of
+                        false -> false
+                        _ -> true
+                    end end;
         _ ->
             false end.
 
@@ -122,7 +124,6 @@ time_interval(Opts) ->
   {MegaSecs, Secs, _} = os:timestamp(),
   trunc((MegaSecs * 1000000 + (Secs + AddSeconds)) / IntervalLength).
 
--spec check_candidate(token(), secret(), time(), time(), proplist()) -> boolean().
 check_candidate(Token, Secret, Current, Last, Opts) ->
     case Current of
         Last ->

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -17,6 +17,7 @@
 
 -module(pot).
 
+
 -export([valid_token/1, valid_token/2]).
 -export([hotp/2, hotp/3]).
 -export([totp/1, totp/2]).

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -23,6 +23,7 @@
 -export([valid_hotp/2, valid_hotp/3]).
 -export([valid_totp/2, valid_totp/3]).
 -export([time_interval/1]).
+-export([check_candidate/5]).
 
 
 -type token() :: binary().
@@ -110,7 +111,6 @@ valid_totp(Token, Secret, Opts) ->
                     true;
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
-                    AddWindow = proplists:get_value(addwindow, Opts, 0),
                     check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) end;
         _ ->
             false end.

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -122,7 +122,8 @@ time_interval(Opts) ->
   {MegaSecs, Secs, _} = os:timestamp(),
   trunc((MegaSecs * 1000000 + (Secs + AddSeconds)) / IntervalLength).
 
-check_candidate(Token, Secret, Current, Last, Opts) when Current =< Last ->
+-spec valid_totp(token(), secret(), time(), time(), proplist()) -> boolean().
+check_candidate(Token, Secret, Current, Last, Opts) ->
     case Current of
         Last ->
             false;

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -122,7 +122,7 @@ time_interval(Opts) ->
   {MegaSecs, Secs, _} = os:timestamp(),
   trunc((MegaSecs * 1000000 + (Secs + AddSeconds)) / IntervalLength).
 
--spec valid_totp(token(), secret(), time(), time(), proplist()) -> boolean().
+-spec check_candidate(token(), secret(), time(), time(), proplist()) -> boolean().
 check_candidate(Token, Secret, Current, Last, Opts) ->
     case Current of
         Last ->

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -115,7 +115,7 @@ valid_totp(Token, Secret, Opts) ->
         _ ->
             false end.
 
-
+-spec time_interval(proplist()).
 time_interval(Opts) ->
   IntervalLength = proplists:get_value(interval_length, Opts, 30),
   AddSeconds = proplists:get_value(addwindow, Opts, 0) * proplists:get_value(interval_length, Opts, 30),

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -110,12 +110,10 @@ valid_totp(Token, Secret, Opts) ->
                     true;
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
-                    case check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) of
-                        false -> false
-                        _ -> true
-                    end end;
+                    check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) end;
         _ ->
             false end.
+
 
 -spec time_interval(proplist()) -> time().
 time_interval(Opts) ->
@@ -124,7 +122,7 @@ time_interval(Opts) ->
   {MegaSecs, Secs, _} = os:timestamp(),
   trunc((MegaSecs * 1000000 + (Secs + AddSeconds)) / IntervalLength).
 
-check_candidate(Token, Secret, Current, Last, Opts) ->
+check_candidate(Token, Secret, Current, Last, Opts) when Current =< Last ->
     case Current of
         Last ->
             false;

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -110,7 +110,7 @@ valid_totp(Token, Secret, Opts) ->
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
                     AddWindow = proplists:get_value(addwindow, Opts, 0),
-                    check_candidate(Token, Secret, IntervalsNo - Window - AddWindow, IntervalsNo + Window + AddWindow, Opts) end;
+                    check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) end;
         _ ->
             false end.
 

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -114,7 +114,7 @@ valid_totp(Token, Secret, Opts) ->
                     case check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) of
                         false -> false;
                         _ -> true;
-                    end end;
+                    end end.
         _ ->
             false end.
 

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -114,7 +114,7 @@ valid_totp(Token, Secret, Opts) ->
                     case check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) of
                         false -> false;
                         _ -> true;
-                    end end.
+                    end end
         _ ->
             false end.
 

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -110,7 +110,7 @@ valid_totp(Token, Secret, Opts) ->
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
                     AddWindow = proplists:get_value(addwindow, Opts, 0),
-                    check_candidate(Token, Secret, IntervalsNo - Window - AddWindow, IntervalsNo + Window, Opts) end;
+                    check_candidate(Token, Secret, IntervalsNo - Window - AddWindow, IntervalsNo + Window + AddWindow, Opts) end;
         _ ->
             false end.
 

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -29,7 +29,7 @@
 -type secret() :: binary().
 -type proplistitem() :: {atom(), term()}.
 -type proplist() :: [proplistitem()] | [].
-
+-type time() :: integer().
 
 -spec valid_token(token()) -> boolean().
 valid_token(Token) ->
@@ -115,7 +115,7 @@ valid_totp(Token, Secret, Opts) ->
         _ ->
             false end.
 
--spec time_interval(proplist()).
+-spec time_interval(proplist()) -> time().
 time_interval(Opts) ->
   IntervalLength = proplists:get_value(interval_length, Opts, 30),
   AddSeconds = proplists:get_value(addwindow, Opts, 0) * proplists:get_value(interval_length, Opts, 30),

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -110,7 +110,10 @@ valid_totp(Token, Secret, Opts) ->
                     true;
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
-                    check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) end;
+                    case check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) of
+                        false -> false;
+                        _ -> true;
+                    end end;
         _ ->
             false end.
 

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -111,7 +111,7 @@ valid_totp(Token, Secret, Opts) ->
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
                     AddWindow = proplists:get_value(addwindow, Opts, 0),
-                    check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + AddWindow, Opts) end;
+                    check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) end;
         _ ->
             false end.
 

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -109,7 +109,8 @@ valid_totp(Token, Secret, Opts) ->
                     true;
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
-                    check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) end;
+                    AddWindow = proplists:get_value(addwindow, Opts, 0),
+                    check_candidate(Token, Secret, IntervalsNo - AddWindow, IntervalsNo + Window, Opts) end;
         _ ->
             false end.
 

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -115,9 +115,10 @@ valid_totp(Token, Secret, Opts) ->
 
 
 time_interval(Opts) ->
+  AddSeconds = proplists:get_value(addseconds, Opts, 0)
   IntervalLength = proplists:get_value(interval_length, Opts, 30),
   {MegaSecs, Secs, _} = os:timestamp(),
-  trunc((MegaSecs * 1000000 + Secs) / IntervalLength).
+  trunc((MegaSecs * 1000000 + (Secs + AddSeconds)) / IntervalLength).
 
 check_candidate(Token, Secret, Current, Last, Opts) when Current =< Last ->
     case Current of

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -109,7 +109,6 @@ valid_totp(Token, Secret, Opts) ->
                     true;
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
-                    AddWindow = proplists:get_value(addwindow, Opts, 0),
                     check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) end;
         _ ->
             false end.
@@ -117,7 +116,7 @@ valid_totp(Token, Secret, Opts) ->
 
 time_interval(Opts) ->
   IntervalLength = proplists:get_value(interval_length, Opts, 30),
-  AddSeconds = proplists:get_value(addwindow, Opts, 0) * IntervalLength,
+  AddSeconds = proplists:get_value(addwindow, Opts, 0) * proplists:get_value(interval_length, Opts, 30),
   {MegaSecs, Secs, _} = os:timestamp(),
   trunc((MegaSecs * 1000000 + (Secs + AddSeconds)) / IntervalLength).
 

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -17,7 +17,6 @@
 
 -module(pot).
 
-
 -export([valid_token/1, valid_token/2]).
 -export([hotp/2, hotp/3]).
 -export([totp/1, totp/2]).
@@ -36,7 +35,6 @@
 valid_token(Token) ->
     valid_token(Token, []).
 
-
 -spec valid_token(token(), proplist()) -> boolean().
 valid_token(Token, Opts) when is_binary(Token) ->
     Length = proplists:get_value(token_length, Opts, 6),
@@ -46,11 +44,9 @@ valid_token(Token, Opts) when is_binary(Token) ->
         false ->
             false end.
 
-
 -spec hotp(secret(), pos_integer()) -> token().
 hotp(Secret, IntervalsNo) ->
     hotp(Secret, IntervalsNo, []).
-
 
 -spec hotp(secret(), pos_integer(), proplist()) -> token().
 hotp(Secret, IntervalsNo, Opts) ->
@@ -72,17 +68,14 @@ hotp(Secret, IntervalsNo, Opts) ->
 totp(Secret) ->
     totp(Secret, []).
 
-
 -spec totp(secret(), proplist()) -> token().
 totp(Secret, Opts) ->
     IntervalsNo = time_interval(Opts),
     hotp(Secret, IntervalsNo, Opts).
 
-
 -spec valid_hotp(token(), secret()) -> boolean().
 valid_hotp(Token, Secret) ->
     valid_hotp(Token, Secret, []).
-
 
 -spec valid_hotp(token(), secret(), proplist()) -> boolean().
 valid_hotp(Token, Secret, Opts) ->
@@ -95,11 +88,9 @@ valid_hotp(Token, Secret, Opts) ->
         _ ->
             false end.
 
-
 -spec valid_totp(token(), secret()) -> boolean().
 valid_totp(Token, Secret) ->
     valid_totp(Token, Secret, []).
-
 
 -spec valid_totp(token(), secret(), proplist()) -> boolean().
 valid_totp(Token, Secret, Opts) ->
@@ -112,9 +103,10 @@ valid_totp(Token, Secret, Opts) ->
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
                     case check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) of
-                        false -> false;
-                        _ -> true;
-                    end end
+                        false ->
+                            false;
+                        _ ->
+                            true end end;
         _ ->
             false end.
 

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -109,14 +109,15 @@ valid_totp(Token, Secret, Opts) ->
                     true;
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
-                    check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + Window, Opts) end;
+                    AddWindow = proplists:get_value(addwindow, Opts, 0),
+                    check_candidate(Token, Secret, IntervalsNo - Window - AddWindow, IntervalsNo + Window, Opts) end;
         _ ->
             false end.
 
 
 time_interval(Opts) ->
-  AddSeconds = proplists:get_value(addseconds, Opts, 0),
   IntervalLength = proplists:get_value(interval_length, Opts, 30),
+  AddSeconds = proplists:get_value(addwindow, Opts, 0) * IntervalLength,
   {MegaSecs, Secs, _} = os:timestamp(),
   trunc((MegaSecs * 1000000 + (Secs + AddSeconds)) / IntervalLength).
 

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -22,6 +22,7 @@
 -export([totp/1, totp/2]).
 -export([valid_hotp/2, valid_hotp/3]).
 -export([valid_totp/2, valid_totp/3]).
+-export([time_interval/1]).
 
 
 -type token() :: binary().
@@ -110,7 +111,7 @@ valid_totp(Token, Secret, Opts) ->
                 _ ->
                     Window = proplists:get_value(window, Opts, 0),
                     AddWindow = proplists:get_value(addwindow, Opts, 0),
-                    check_candidate(Token, Secret, IntervalsNo - AddWindow, IntervalsNo + Window, Opts) end;
+                    check_candidate(Token, Secret, IntervalsNo - Window, IntervalsNo + AddWindow, Opts) end;
         _ ->
             false end.
 


### PR DESCRIPTION
Some Android devices are at least 15 seconds ahead than UTC due to not compensating GPS time.
(http://www.businessinsider.com/neil-degrasse-tyson-the-time-on-your-android-phone-is-incorrect-2012-3)

If an user has Telecom Operator synced time, and an app like Google Authenticator, it will produce future tokens (15 seconds ahead) than server NTP time.

To avoid this I added an option to produce tokens in the future and bumped window to 1.

Example:

:pot.valid_totp(token, secret, [window: 1, addwindow: 1])