### PR TITLE
Added option `timestamp` to create totp for a given time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ IsValid = pot:valid_totp(Token, Secret, [{window, 1}, {addWindow, 1}]),
 % Do something
 ```
 
+### Create a time based token for given time
+
+Time format is `{MegaSecs, Secs, MicroSecs}` received by os:timestamp()
+
+```erlang
+Secret = <<"MFRGGZDFMZTWQ2LK">>,
+Token = pot:totp(Secret, [{timestamp, {1518, 179058, 919315}}]),
+% Token will be <<"151469">>
+```
+
+
 ## Usage (Elixir)
 
 Include POT in your `mix.exs` as a dependency:
@@ -154,6 +165,16 @@ secret = "MFRGGZDFMZTWQ2LK"
 token = "123456"
 is_valid = :pot.valid_totp(token, secret, [window: 1, addwindow: 1])
 # Do something
+```
+
+### Create a time based token for given time
+
+Time format is `{MegaSecs, Secs, MicroSecs}` received by :os.timestamp()
+
+```elixir
+secret = "MFRGGZDFMZTWQ2LK"
+token = :pot.totp(secret, [timestamp: {1518, 179058, 919315}])
+# Token will be <<"151469">>
 ```
 
 ## Credits

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -115,7 +115,7 @@ valid_totp(Token, Secret, Opts) ->
 time_interval(Opts) ->
   IntervalLength = proplists:get_value(interval_length, Opts, 30),
   AddSeconds = proplists:get_value(addwindow, Opts, 0) * proplists:get_value(interval_length, Opts, 30),
-  {MegaSecs, Secs, _} = os:timestamp(),
+  {MegaSecs, Secs, _} = proplists:get_value(timestamp, Opts, os:timestamp()),
   trunc((MegaSecs * 1000000 + (Secs + AddSeconds)) / IntervalLength).
 
 check_candidate(Token, Secret, Current, Last, Opts) when Current =< Last ->

--- a/test/totp_generation_tests.erl
+++ b/test/totp_generation_tests.erl
@@ -8,6 +8,10 @@ generating_current_totp_and_validating_test_() ->
             fun stop/1,
             fun generating_current_totp_and_validating/1}.
 
+generating_totp_for_given_timestamp_and_compare_test_() ->
+    {setup, fun start/0,
+        fun stop/1,
+        fun generating_totp_for_given_timestamp_and_compare/1}.
 
 start() ->
     ok.
@@ -24,6 +28,10 @@ generating_current_totp_and_validating(_) ->
     Totp = pot:totp(Secret),
     [?_assertEqual(Hotp, Totp)].
 
+generating_totp_for_given_timestamp_and_compare(_) ->
+    Secret = <<"MFRGGZDFMZTWQ2LK">>,
+    Totp = pot:totp(Secret, [{timestamp, {1518, 179058, 919315}}]),
+    [?_assertEqual(Totp, <<"151469">>)].
 
 time_now() ->
     {MegaSecs, Secs, _} = os:timestamp(),


### PR DESCRIPTION
This option can be used for testing otp and in cases where the client timing needs to be accounted.