### PR TITLE
Return boolean on pot:valid_hotp/2 and pot:valid_hotp/3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: erlang
 otp_release:
+  - 22.0
+  - 21.3
   - 20.3
   - 19.3
   - 18.3
-  - 17.5
 script:
   - make coveralls

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@ Erik Reedstrom
 Peter McLain
 Pedro Vieira
 Julius Beckmann
+Zbigniew Pekala

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -84,7 +84,12 @@ valid_hotp(Token, Secret, Opts) ->
     TokenLength = proplists:get_value(token_length, Opts, 6),
     case valid_token(Token, [{token_length, TokenLength}]) of
         true ->
-            check_candidate(Token, Secret, Last + 1, Last + Trials, Opts);
+            case check_candidate(Token, Secret, Last + 1, Last + Trials, Opts) of
+                false ->
+                    false;
+                _ ->
+                    true
+            end;
         _ ->
             false end.
 

--- a/test/hotp_validity_tests.erl
+++ b/test/hotp_validity_tests.erl
@@ -44,7 +44,7 @@ stop(_) ->
 
 checking_hotp_validity_without_range(_) ->
     Secret = <<"MFRGGZDFMZTWQ2LK">>,
-    [?_assertEqual(pot:valid_hotp(pot:hotp(Secret, 123), Secret), 123)].
+    [?_assertEqual(pot:valid_hotp(pot:hotp(Secret, 123), Secret), true)].
 
 
 validating_correct_hotp_after_exhaustion(_) ->
@@ -62,7 +62,7 @@ retrieving_proper_interval_from_validator(_) ->
     Secret = <<"MFRGGZDFMZTWQ2LK">>,
     Totp = <<"713385">>,
     Result = pot:valid_hotp(Totp, Secret, [{last, 1}, {trials, 5}]),
-    [?_assertEqual(Result, 4),
+    [?_assertEqual(Result, true),
      ?_assertEqual(pot:hotp(Secret, 4), Totp)].
 
 


### PR DESCRIPTION
Based on the specs https://github.com/yuce/pot/blob/master/src/pot.erl#L76 `pot:valid_hotp/2` and `pot: valid_hotp/3` should return boolean.