### PR TITLE
added namespace to avoid name collision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ otp_release:
   - 21.3
   - 20.3
   - 19.3
-  - 18.3
 script:
   - make coveralls

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Peter McLain
 Pedro Vieira
 Julius Beckmann
 Zbigniew Pekala
+Girish Ramnani

--- a/src/pot.erl
+++ b/src/pot.erl
@@ -53,7 +53,7 @@ hotp(Secret, IntervalsNo, Opts) ->
     DigestMethod = proplists:get_value(digest_method, Opts, sha),
     TokenLength = proplists:get_value(token_length, Opts, 6),
     IsLower = {lower, proplists:get_bool(casefold, Opts)},
-    Key = base32:decode(Secret, [{lower, IsLower}]),
+    Key = pot_base32:decode(Secret, [{lower, IsLower}]),
     Msg = <<IntervalsNo:8/big-unsigned-integer-unit:8>>,
     Digest = crypto:hmac(DigestMethod, Key, Msg),
     <<_:19/binary, Ob:8>> = Digest,

--- a/src/pot_base32.erl
+++ b/src/pot_base32.erl
@@ -17,7 +17,7 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
--module(base32).
+-module(pot_base32).
 -export([encode/1, encode/2, decode/1, decode/2]).
 
 -ifdef(TEST).


### PR DESCRIPTION
`base32` is a very common module name due to which at times a module name conflict occurs ( happened in my project ). So added `pot_` prefix to `base32` module