### PR TITLE
Improved types, README documentation, simplify and extend unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ REBAR = rebar3
 
 .PHONY: all compile clean cover coveralls release test dialyze
 
-all: deps compile
+all: compile
 
 compile:
 	$(REBAR) compile

--- a/README.md
+++ b/README.md
@@ -4,25 +4,30 @@
 
 # POT
 
+- [Introduction](#introduction)
+- [Version History](#version-history)
+- [Usage](#usage)
+- [Function Reference](#function-ref)
+- [Examples (Erlang)](#examples-erlang)
+- [Examples (Elixir)](#examples-elixir)
+- [Credits](#credits)
+- [Licence](#license)
+
 ## Introduction
 
-POT is an Erlang library for generating one time passwords. It supports both HMAC-based one time passwords (HOTP) and time based ones (TOTP). The generated passwords are compatible with [Google Authenticator](http://en.wikipedia.org/wiki/Google_Authenticator).
+POT is an Erlang library for generating one time passwords. It supports both HMAC-based one time passwords (HOTP) and time based ones (TOTP). The generated passwords are based on [RFC 4226][rfc4226] and [RFC 6238][rfc6238], compatible with [Google Authenticator][google_auth_wiki].
 
-POT is an almost direct translation of the Python [OneTimePass](https://github.com/tadeck/onetimepass) library.
+POT is an almost direct translation of the Python [OneTimePass][onetimepass] library.
 
-POT should work with any recent version of [Erlang/OTP](http://www.erlang.org/), [Elixir](http://elixir-lang.org/) and other Erlang VM based languages.
+POT should work with any recent version of [Erlang/OTP][erlang], [Elixir][elixir], and other Erlang VM based languages.
 
 In order to learn more about one time password generation, see the following Wikipedia articles:
 
-- [Google Authenticator](http://en.wikipedia.org/wiki/Google_Authenticator)
-- [HMAC-based One-time Password Algorithm](http://en.wikipedia.org/wiki/HMAC-based_One-time_Password_Algorithm)
-- [Time-based One-time Password Algorithm](http://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
+- [Google Authenticator][google_auth_wiki]
+- [HMAC-based One-time Password Algorithm][hotp_wiki] ([RFC 4226][rfc4226])
+- [Time-based One-time Password Algorithm][totp_wiki] ([RFC 6238][rfc6238])
 
-### TODO
-
-- Documentation.
-
-## News
+## Version History
 
 ### 2019-10-16
 
@@ -61,15 +66,197 @@ In order to learn more about one time password generation, see the following Wik
 ### 2015-01-18
 
   - Initial version
+  
+## Usage
 
+See the sections below on using `pot` in your Erlang and Elixir project.
 
-## Usage (Erlang)
+### Erlang
 
-We recommend using [rebar3](https://github.com/erlang/rebar3) for managing dependencies and building the library. POT is available on hex.pm, so you can just include the following in your `rebar.config`:
+We recommend using [rebar3][rebar3] for managing dependencies and building the library. POT is available on hex.pm, so you can just include the following in your `rebar.config`:
 
 ```
 {deps, [pot]}.
 ```
+
+See the [Erlang examples](#examples-erlang)
+
+### Elixir
+
+Include POT in your `mix.exs` as a dependency:
+
+```elixir
+defp deps do
+    [{:pot, "~>0.10.1"}]
+end
+```
+
+## <a id="function-ref"></a>Function Reference
+
+The functions below refer to the following common parameters:
+
+| Parameter  | Type     |
+|------------|----------|
+| `Interval` | integer  |
+| `Secret`   | string\* |
+| `Token`    | string\* |
+
+- `Interval` is an integer that represents the counter value, the "moving factor" referenced in [RFC 4226][rfc4226]. It is an 8 byte unsigned integer; if a negative and/or too large integer is passed, it will be 2's complemented and truncated appropriately.
+- `Secret` is a base-32-encoded secret key. Generally, it should be at least 128 bits, preferably 160 bits. 
+- `Token` is a HOTP/TOTP value represented as a string\*. This is generally a 6-digit number, e.g., "123456", but its length may be modulated with the `token_length` option.
+
+\*Note: for [Erlang][erlang] uses of `pot`, all strings should be in `binary()` format.
+
+### Token Generation Functions
+
+#### `hotp/2,3`
+
+Generate an [RFC 4226][rfc4226] compatible HOTP token. 
+
+Erlang:
+
+```
+pot:hotp(Secret, Interval) -> Token
+pot:hotp(Secret, Interval, Options) -> Token
+```
+
+Elixir:
+
+```
+:pot.hotp(Secret, Interval) -> Token
+:pot.hotp(Secret, Interval, Options) -> Token
+```
+
+The following `Options` are allowed:
+
+| Option          | Type        | Default |
+|-----------------|-------------|---------|
+| `digest_method` | atom        | sha     |
+| `token_length`  | integer > 0 | 6       |
+
+- `digest_method` controls the signing algorithm passed to the [Erlang][erlang] `crypto` module's [`hmac`][crypto_hmac] function. For [RFC 4226][rfc4226] compliant tokens, it must be set to `sha`. For [RFC 6238][rfc6238] compliant tokens, additional values such as `sha256` or `sha512` may be used.
+- `token_length` controls the number of digits in output `Token`.
+
+#### `totp/1,2`
+
+Generate an [RFC 6238][rfc6238] compatible TOTP token. 
+
+Erlang:
+
+```
+pot:totp(Secret) -> Token
+pot:totp(Secret, Options) -> Token
+```
+
+Elixir:
+
+```
+:pot.totp(Secret) -> Token
+:pot.totp(Secret, Options) -> Token
+```
+
+The following `Options` are allowed:
+
+| Option            | Type        | Default/Reference        |
+|-------------------|-------------|--------------------------|
+| `addwindow`       | integer     | 0                        |
+| `digest_method`   | atom        | from [hotp/2,3](#hotp23) |
+| `interval_length` | integer > 0 | 30                       |
+| `timestamp`       | timestamp   | [`os:timestamp()`][ts]   |
+| `token_length`    | integer > 0 | from [hotp/2,3](#hotp23) |
+
+- `addwindow` acts as an offset to the `Interval` extrapolated from dividing the `timestamp` by the `interval_length` per the algorithm described in [RFC 6238][rfc6238].
+- `interval_length` controls the number of seconds for the `Interval` computation.
+- `timestamp` may be passed to specify a custom timestamp (in Erlang [timestamp][ts] format) to use for computing the `Interval` used to generate a `Token`.
+
+### Token Validation Functions
+
+#### `valid_token/1,2`
+
+Validate that a given `Token` has the correct format (correct length, all digits).
+
+Erlang:
+
+```
+pot:valid_token(Token) -> Boolean
+pot:valid_token(Token, Options) -> Boolean
+```
+
+Elixir:
+
+```
+:pot.valid_token(Token) -> Boolean
+:pot.valid_token(Token, Options) -> Boolean
+```
+
+The following `Options` are allowed:
+
+| Option            | Type        | Default/Reference        |
+|-------------------|-------------|--------------------------|
+| `token_length`    | integer > 0 | from [hotp/2,3](#hotp23) |
+
+#### `valid_hotp/2,3`
+
+Validate an [RFC 4226][rfc4226] compatible HOTP token. Returns `true` if the `Token` is valid. 
+
+Erlang:
+
+```
+pot:valid_hotp(Token, Secret) -> Boolean
+pot:valid_hotp(Token, Secret, Options) -> Boolean
+```
+
+Elixir:
+
+```
+:pot.valid_hotp(Token, Secret) -> Boolean
+:pot.valid_hotp(Token, Secret, Options) -> Boolean
+```
+
+The following `Options` are allowed:
+
+| Option            | Type        | Default/Reference        |
+|-------------------|-------------|--------------------------|
+| `digest_method`   | atom        | from [hotp/2,3](#hotp23) |
+| `last`            | integer     | 1                        |
+| `token_length`    | integer > 0 | from [hotp/2,3](#hotp23) |
+| `trials`          | integer > 0 | 1000                     |
+
+- `last` is the `Interval` value of the previous valid `Token`; the next `Interval` after `last` is used as the first candidate for validating the `Token`.
+- `trials` controls the number of incremental `Interval` values after `last` to try when validating the `Token`. If a matching candidate is not found within `trials` attempts, the `Token` is considered invalid.
+
+#### `valid_totp/2,3`
+
+Validate an [RFC 6238][rfc6238] compatible TOTP token. Returns `true` if the `Token` is valid.
+
+Erlang:
+
+```
+pot:valid_totp(Token, Secret) -> Boolean
+pot:valid_totp(Token, Secret, Options) -> Boolean
+```
+
+Elixir:
+
+```
+:pot.valid_totp(Token, Secret) -> Boolean
+:pot.valid_totp(Token, Secret, Options) -> Boolean
+```
+
+The following `Options` are allowed:
+
+| Option            | Type        | Default/Reference        |
+|-------------------|-------------|--------------------------|
+| `addwindow`       | integer     | from [totp/1,2](#totp12) |
+| `digest_method`   | atom        | from [hotp/2,3](#hotp23) |
+| `interval_length` | integer > 0 | from [totp/1,2](#totp12) |
+| `timestamp`       | timestamp   | from [totp/1,2](#totp12) |
+| `token_length`    | integer > 0 | from [hotp/2,3](#hotp23) |
+| `window`          | integer > 0 | 0                        |
+
+- `window` is a range used for expanding `Interval` value derived from the `timestamp`. This is done by considering the `window` `Interval`s before *and* after the one derived from the `timestamp`. This allows validation to be relaxed to allow for successful validation of TOTP `Token`s generated by clients with some degree of unknown clock drift from the server, as well as some client entry delay. 
+
+## Examples (Erlang)
 
 POT works with binary tokens and secrets.
 
@@ -113,16 +300,16 @@ IsValid = pot:valid_hotp(Token, Secret, [{last, LastUsed}]),
 
 ```erlang
 Secret = <<"MFRGGZDFMZTWQ2LK">>,
-Token = pot:totp(Secret, [{addWindow, 1}]),
+Token = pot:totp(Secret, [{addwindow, 1}]),
 % Do something
 ```
 
-### Check some time based token on Android devices with 15 seconds ahead
+### Check a time based token from a mobile device with 30 seconds ahead and a ±1 interval tolerance
 
 ```erlang
 Secret = <<"MFRGGZDFMZTWQ2LK">>,
 Token = <<"123456">>,
-IsValid = pot:valid_totp(Token, Secret, [{window, 1}, {addWindow, 1}]),
+IsValid = pot:valid_totp(Token, Secret, [{window, 1}, {addwindow, 1}]),
 % Do something
 ```
 
@@ -136,16 +323,7 @@ Token = pot:totp(Secret, [{timestamp, {1518, 179058, 919315}}]),
 % Token will be <<"151469">>
 ```
 
-
-## Usage (Elixir)
-
-Include POT in your `mix.exs` as a dependency:
-
-```elixir
-defp deps do
-    [{:pot, "~>0.10.1"}]
-end
-```
+## Examples (Elixir)
 
 ### Create a time based token
 
@@ -191,7 +369,7 @@ token = :pot.totp(secret, [addwindow: 1])
 # Do something
 ```
 
-### Check some time based token on Android devices with 15 seconds ahead
+### Check a time based token from a mobile device with 30 seconds ahead and a ±1 interval tolerance
 
 ```elixir
 secret = "MFRGGZDFMZTWQ2LK"
@@ -236,3 +414,15 @@ BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR P
 NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
 DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+[onetimepass]: https://github.com/tadeck/onetimepass
+[erlang]: http://www.erlang.org
+[elixir]: http://elixir-lang.org
+[rfc4226]: https://tools.ietf.org/html/rfc4226
+[rfc6238]: https://tools.ietf.org/html/rfc6238
+[rebar3]: https://github.com/erlang/rebar3
+[google_auth_wiki]: http://en.wikipedia.org/wiki/Google_Authenticator
+[hotp_wiki]: http://en.wikipedia.org/wiki/HMAC-based_One-time_Password_Algorithm
+[totp_wiki]: http://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm
+[crypto_hmac]: http://erlang.org/doc/man/crypto.html#hmac-3
+[ts]: http://erlang.org/doc/man/os.html#timestamp-0

--- a/test/hotp_generation_tests.erl
+++ b/test/hotp_generation_tests.erl
@@ -3,50 +3,51 @@
 -include_lib("eunit/include/eunit.hrl").
 
 
-hotp_generation_from_secret_test_() ->
-    {setup, fun start/0,
-            fun stop/1,
-            fun hotp_generation_from_secret/1}.
-
-
-hotp_generation_for_different_intervals_test_() ->
-    {setup, fun start/0,
-            fun stop/1,
-            fun hotp_generation_for_different_intervals/1}.
-
-hotp_generation_with_padding_test_() ->
-    {setup, fun start/0,
-            fun stop/1,
-            fun hotp_generation_with_padding/1}.
-
-hotp_generation_with_multiple_padding_test_() ->
-    {setup, fun start/0,
-            fun stop/1,
-            fun hotp_generation_with_multiple_padding/1}.
+all_test_() ->
+    {foreach,
+     fun start/0,
+     fun stop/1,
+     [fun hotp_generation_from_secret/1,
+      fun hotp_generation_for_different_intervals/1,
+      fun hotp_generation_with_padding/1,
+      fun hotp_generation_with_multiple_padding/1,
+      fun hotp_generation_unsigned_interval/1]}.
 
 
 start() ->
-    ok.
+    #{secret1 => <<"MFRGGZDFMZTWQ2LK">>,
+      secret2 => <<"RWLMFU237M4RJIFA">>}.
 
 
 stop(_) ->
     ok.
 
 
-hotp_generation_from_secret(_) ->
-    Secret = <<"MFRGGZDFMZTWQ2LK">>,
+hotp_generation_from_secret(#{secret1 := Secret}) ->
     [?_assertEqual(pot:hotp(Secret, 1), <<"765705">>)].
 
 
-hotp_generation_for_different_intervals(_) ->
-    Secret = <<"MFRGGZDFMZTWQ2LK">>,
-    [?_assertEqual(pot:hotp(Secret, 1), <<"765705">>),
+hotp_generation_for_different_intervals(#{secret1 := Secret}) ->
+    [?_assertEqual(pot:hotp(Secret, 0), <<"462371">>),
+     ?_assertEqual(pot:hotp(Secret, 1), <<"765705">>),
      ?_assertEqual(pot:hotp(Secret, 2), <<"816065">>)].
 
-hotp_generation_with_padding(_) ->
-   Secret = <<"MFRGGZDFMZTWQ2LK">>,
+
+hotp_generation_with_padding(#{secret1 := Secret}) ->
    [?_assertEqual(pot:hotp(Secret, 19), <<"088239">>)].
 
-hotp_generation_with_multiple_padding(_) ->
-   Secret = <<"RWLMFU237M4RJIFA">>,
+
+hotp_generation_with_multiple_padding(#{secret2 := Secret}) ->
    [?_assertEqual(pot:hotp(Secret, 48930987), <<"000371">>)].
+
+
+hotp_generation_unsigned_interval(#{secret1 := Secret}) ->
+    [{"negative intervals are equivalent to 64-bit unsigned representations (2^64 - 1)",
+      ?_assertEqual(pot:hotp(Secret,  18446744073709551615),
+                    pot:hotp(Secret, -1))},
+     {"negative intervals are equivalent to 64-bit unsigned representations (2^63 - 1)",
+      ?_assertEqual(pot:hotp(Secret,  9223372036854775808),
+                    pot:hotp(Secret, -9223372036854775808))},
+     {"large intervals are equivalent to 64-bit truncated representations (2^64 + 1)",
+      ?_assertEqual(pot:hotp(Secret, 18446744073709551617),
+                    pot:hotp(Secret, 1))}].

--- a/test/hotp_validity_tests.erl
+++ b/test/hotp_validity_tests.erl
@@ -11,7 +11,7 @@ checking_hotp_validity_without_range_test_() ->
      [fun checking_hotp_validity_without_range/1,
       fun checking_hotp_validity_max_default_range/1,
       fun checking_hotp_validity_past_max_default_range/1,
-      fun validatinging_invalid_token_hotp/1,
+      fun validating_invalid_token_hotp/1,
       fun validating_correct_hotp_after_exhaustion/1,
       fun validating_correct_totp_as_hotp/1,
       fun retrieving_proper_interval_from_validator/1,
@@ -41,7 +41,7 @@ checking_hotp_validity_past_max_default_range(Secret) ->
       ?_assertNot(pot:valid_hotp(pot:hotp(Secret, 1002), Secret))}].
 
 
-validatinging_invalid_token_hotp(Secret) ->
+validating_invalid_token_hotp(Secret) ->
      [?_assertNot(pot:valid_hotp(<<"abcdef">>, Secret))].
 
 

--- a/test/hotp_validity_tests.erl
+++ b/test/hotp_validity_tests.erl
@@ -11,6 +11,7 @@ checking_hotp_validity_without_range_test_() ->
      [fun checking_hotp_validity_without_range/1,
       fun checking_hotp_validity_max_default_range/1,
       fun checking_hotp_validity_past_max_default_range/1,
+      fun validatinging_invalid_token_hotp/1,
       fun validating_correct_hotp_after_exhaustion/1,
       fun validating_correct_totp_as_hotp/1,
       fun retrieving_proper_interval_from_validator/1,
@@ -38,6 +39,10 @@ checking_hotp_validity_max_default_range(Secret) ->
 checking_hotp_validity_past_max_default_range(Secret) ->
     [{"hotp beyond the max # of trials (1000) past the start (1) is invalid",
       ?_assertNot(pot:valid_hotp(pot:hotp(Secret, 1002), Secret))}].
+
+
+validatinging_invalid_token_hotp(Secret) ->
+     [?_assertNot(pot:valid_hotp(<<"abcdef">>, Secret))].
 
 
 validating_correct_hotp_after_exhaustion(Secret) ->

--- a/test/preliminary_check_tests.erl
+++ b/test/preliminary_check_tests.erl
@@ -3,16 +3,12 @@
 -include_lib("eunit/include/eunit.hrl").
 
 
-valid_token_test_() ->
-    {setup, fun start/0,
-            fun stop/1,
-            fun valid_token/1}.
-
-
-variable_length_in_possible_token_test_() ->
-    {setup, fun start/0,
-            fun stop/1,
-            fun variable_length_in_possible_token/1}.
+all_test_() ->
+    {foreach,
+     fun start/0,
+     fun stop/1,
+     [fun valid_token/1,
+      fun variable_length_in_possible_token/1]}.
 
 
 start() ->
@@ -24,11 +20,11 @@ stop(_) ->
 
 
 valid_token(_) ->
-    [?_assertEqual(pot:valid_token(<<"123456">>), true),
-     ?_assertEqual(pot:valid_token(<<"abcdef">>), false),
-     ?_assertEqual(pot:valid_token(<<"12345678">>), false)].
+    [?_assert(pot:valid_token(<<"123456">>)),
+     ?_assertNot(pot:valid_token(<<"abcdef">>)),
+     ?_assertNot(pot:valid_token(<<"12345678">>))].
 
 
 variable_length_in_possible_token(_) ->
-    [?_assertEqual(pot:valid_token(<<"1234567">>), false),
-     ?_assertEqual(pot:valid_token(<<"1234567">>, [{token_length, 7}]), true)].
+    [?_assertNot(pot:valid_token(<<"1234567">>)),
+     ?_assert(pot:valid_token(<<"1234567">>, [{token_length, 7}]))].

--- a/test/totp_validity_tests.erl
+++ b/test/totp_validity_tests.erl
@@ -9,7 +9,7 @@ totp_validity_test_() ->
      fun stop/1,
      [fun validating_totp_for_same_secret/1,
       fun validating_invalid_totp_for_same_secret/1,
-      fun validatinging_invalid_token_hotp/1,
+      fun validating_invalid_token_hotp/1,
       fun validating_correct_hotp_as_totp/1,
       fun validating_past_future_totp_too_small_window/1,
       fun validating_past_future_totp_with_window/1]}.
@@ -31,7 +31,7 @@ validating_invalid_totp_for_same_secret(Secret) ->
     [?_assertNot(pot:valid_totp(<<"123456">>, Secret))].
 
 
-validatinging_invalid_token_hotp(Secret) ->
+validating_invalid_token_hotp(Secret) ->
      [?_assertNot(pot:valid_totp(<<"abcdef">>, Secret))].
 
 

--- a/test/totp_validity_tests.erl
+++ b/test/totp_validity_tests.erl
@@ -9,36 +9,37 @@ totp_validity_test_() ->
      fun stop/1,
      [fun validating_totp_for_same_secret/1,
       fun validating_invalid_totp_for_same_secret/1,
+      fun validatinging_invalid_token_hotp/1,
       fun validating_correct_hotp_as_totp/1,
       fun validating_past_future_totp_too_small_window/1,
       fun validating_past_future_totp_with_window/1]}.
 
 
 start() ->
-    ok.
+    _Secret = <<"MFRGGZDFMZTWQ2LK">>.
 
 
 stop(_) ->
     ok.
 
 
-validating_totp_for_same_secret(_) ->
-    Secret = <<"MFRGGZDFMZTWQ2LK">>,
+validating_totp_for_same_secret(Secret) ->
     [?_assert(pot:valid_totp(pot:totp(Secret), Secret))].
 
 
-validating_invalid_totp_for_same_secret(_) ->
-    Secret = <<"MFRGGZDFMZTWQ2LK">>,
+validating_invalid_totp_for_same_secret(Secret) ->
     [?_assertNot(pot:valid_totp(<<"123456">>, Secret))].
 
 
-validating_correct_hotp_as_totp(_) ->
-    Secret = <<"MFRGGZDFMZTWQ2LK">>,
+validatinging_invalid_token_hotp(Secret) ->
+     [?_assertNot(pot:valid_totp(<<"abcdef">>, Secret))].
+
+
+validating_correct_hotp_as_totp(Secret) ->
     [?_assertNot(pot:valid_totp(pot:hotp(Secret, 1), Secret))].
 
 
-validating_past_future_totp_too_small_window(_) ->
-    Secret = <<"MFRGGZDFMZTWQ2LK">>,
+validating_past_future_totp_too_small_window(Secret) ->
     IntervalOpts = [{timestamp, os:timestamp()}],
     N = 5,
     [?_assertNot(pot:valid_totp(pot:totp(Secret, [{addwindow, AW} | IntervalOpts]),
@@ -47,8 +48,7 @@ validating_past_future_totp_too_small_window(_) ->
      || W <- lists:seq(0, N), AW <- lists:seq(-N, N), W < abs(AW)].
 
 
-validating_past_future_totp_with_window(_) ->
-    Secret = <<"MFRGGZDFMZTWQ2LK">>,
+validating_past_future_totp_with_window(Secret) ->
     IntervalOpts = [{timestamp, os:timestamp()}],
     N = 5,
     [?_assert(pot:valid_totp(pot:totp(Secret, [{addwindow, AW} | IntervalOpts]),


### PR DESCRIPTION
* Remove obsolete `deps` target from Makefile.
* Use a single unified eunit test generator for each module's tests, to reduce repetition.
* Leverage the `setup/0` function for storing common test parameters.
* Add tests of invalid tokens in `pot:valid_hotp` and `pot:valid_totp` to achieve full line coverage in unit tests.
* Extend hotp_generation_tests to reason about 0 and negative/very large interval (counter) values.
* Improve type specifications for module parameters, particularly options.
* Rename `time()` to `interval()` for clarity.
* Export types for clients to reference as-needed.
* Remove invalid `casefold` option in `hotp` function (this parameter is not set correctly and is unsupported by underlying base32 decoder, which is already case-insensitive).
* Re-order library functions to group token generation and token validation.
* Update README with TOC, cross-references, links table at the bottom, and function references.
