### PR TITLE
Move coveralls into project_plugins

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{plugins                , [coveralls]}.
+{project_plugins        , [coveralls]}.
 {cover_enabled          , true}.
 {cover_export_enabled   , true}.
 {coveralls_coverdata    , "_build/test/cover/eunit.coverdata"}.


### PR DESCRIPTION
This PR moves `coveralls` to `project_plugins` so that users of `pot` do not download `coveralls` and it's dependencies (i.e., when adding pot as dependency from hex)