### PR TITLE
Migrate from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+---
+name: "build"
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+jobs:
+  ci:
+    name: "Run checks, tests, and docs over ${{matrix.otp_vsn}} and ${{matrix.os}}"
+    runs-on: "${{matrix.os}}"
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    container:
+      image: "erlang:${{matrix.otp_vsn}}"
+    strategy:
+      matrix:
+        otp_vsn: ["19.3", "21.3", "22.3", "23.2"] # omitting 20.3 due to TLS issue
+        os: ["ubuntu-latest"]
+    steps:
+      - uses: "actions/checkout@v2"
+      - run: "make coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: erlang
-otp_release:
-  - 22.0
-  - 21.3
-  - 20.3
-  - 19.3
-script:
-  - make coveralls

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ cover: test
 	$(REBAR) cover --verbose
 
 coveralls: compile cover
-	$(REBAR) coveralls send
+	$(REBAR) as test coveralls send
 
 release:
 	rebar3 hex publish

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![coveralls.io](https://api.travis-ci.org/yuce/pot.svg?branch=master)](https://travis-ci.org/yuce/pot)
+[![Build Status](https://github.com/yuce/pot/workflows/build/badge.svg)](https://github.com/yuce/pot/actions?query=workflow:build)
 [![coveralls.io](https://coveralls.io/repos/github/yuce/pot/badge.svg?branch=master)](https://coveralls.io/github/yuce/pot)
 [![hex.pm](http://img.shields.io/hexpm/v/pot.svg?style=flat)](https://hex.pm/packages/pot)
 

--- a/rebar.config
+++ b/rebar.config
@@ -2,4 +2,4 @@
 {cover_enabled          , true}.
 {cover_export_enabled   , true}.
 {coveralls_coverdata    , "_build/test/cover/eunit.coverdata"}.
-{coveralls_service_name , "travis-ci"}.
+{coveralls_service_name , "github"}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,7 +1,16 @@
-case os:getenv("TRAVIS") of
-  "true" ->
-    JobId   = os:getenv("TRAVIS_JOB_ID"),
-    lists:keystore(coveralls_service_job_id, 1, CONFIG, {coveralls_service_job_id, JobId});
+case {os:getenv("GITHUB_ACTIONS"), os:getenv("GITHUB_TOKEN")} of
+  {"true", Token} when is_list(Token) ->
+    CONFIG1 = [{coveralls_repo_token, Token},
+               {coveralls_service_job_id, os:getenv("GITHUB_RUN_ID")},
+               {coveralls_commit_sha, os:getenv("GITHUB_SHA")},
+               {coveralls_service_number, os:getenv("GITHUB_RUN_NUMBER")} | CONFIG],
+    case os:getenv("GITHUB_EVENT_NAME") =:= "pull_request"
+        andalso string:tokens(os:getenv("GITHUB_REF"), "/") of
+        [_, "pull", PRNO, _] ->
+            [{coveralls_service_pull_request, PRNO} | CONFIG1];
+        _ ->
+            CONFIG1
+    end;
   _ ->
     CONFIG
 end.


### PR DESCRIPTION
travis-ci.org is shut down and no longer operating. Let's use GitHub Actions instead.