### PR TITLE
Updated README with newer elixir dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Include POT in your `mix.exs` as a dependency:
 
 ```elixir
 defp deps do
-    [{:pot, "~>0.10.1"}]
+    [{:pot, "~>1.0.2"}]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Include POT in your `mix.exs` as a dependency:
 
 ```elixir
 defp deps do
-    [{:pot, "~>1.0.2"}]
+    [{:pot, "~> 1.0"}]
 end
 ```
 


### PR DESCRIPTION
We were getting compilation warnings and test errors when trying to use the version listed in the `README.md` in our `mix.exs`:

```
===> Compiling pot
src/pot.erl:58:14: Warning: crypto:hmac/3 is removed; use crypto:mac/4 instead
```

```
** (UndefinedFunctionError) function :crypto.hmac/3 is undefined or private, use crypto:mac/4 instead
```

This PR updates the `mix.exs` dependency example to the latest.